### PR TITLE
Fixed Request-Target for notification signature generation

### DIFF
--- a/woo-doku-jokul/Common/JokulUtils.php
+++ b/woo-doku-jokul/Common/JokulUtils.php
@@ -18,10 +18,18 @@ class JokulUtils
     public function generateSignatureNotification($headers, $body, $secret)
     {
         $digest = base64_encode(hash('sha256', $body, true));
+		$url = get_site_url();
+		$parsedUrl = parse_url($url);
+		$path = $parsedUrl['path'];
+		
+		if ( $path != "/" ) {
+			$path;
+		}
+		
         $rawSignature = "Client-Id:" . $headers['Client-Id'] . "\n"
             . "Request-Id:" . $headers['Request-Id'] . "\n"
             . "Request-Timestamp:" . $headers['Request-Timestamp'] . "\n"
-            . "Request-Target:" ."/wordpress/wp-json/jokul/notification". "\n"
+            . "Request-Target:" . $path . "/wp-json/jokul/notification". "\n"
             . "Digest:" . $digest;
 
         $signature = base64_encode(hash_hmac('sha256', $rawSignature, htmlspecialchars_decode($secret), true));


### PR DESCRIPTION
I added these line of code to get the site URL first then I parse the URL to get the path, after that I make a simple logic to check whether the site URL containing any path or not.

If there is a path, then it should be appended to the `Request-Target`.

```
public function generateSignatureNotification($headers, $body, $secret)
    {
        $digest = base64_encode(hash('sha256', $body, true));
        $url = get_site_url();
	$parsedUrl = parse_url($url);
	$path = $parsedUrl['path'];
		  
	if ( $path != "/" ) {
		$path;
	}
		
        $rawSignature = "Client-Id:" . $headers['Client-Id'] . "\n"
            . "Request-Id:" . $headers['Request-Id'] . "\n"
            . "Request-Timestamp:" . $headers['Request-Timestamp'] . "\n"
            . "Request-Target:" . $path . "/wp-json/jokul/notification". "\n"
            . "Digest:" . $digest;

        $signature = base64_encode(hash_hmac('sha256', $rawSignature, htmlspecialchars_decode($secret), true));
        return 'HMACSHA256=' . $signature;
    }
```

Reference: https://developer.wordpress.org/reference/functions/get_site_url/